### PR TITLE
tar: Fix spurious error message during extraction

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -61,3 +61,4 @@ Authors/contributors include:
 © 2015 Wolfgang Corcoran-Mathe <wcm@sigwinch.xyz>
 © 2016 Mattias Andrée <maandree@kth.se>
 © 2016 Eivind Uggedal <eivind@uggedal.com>
+© 2017 Jim Beveridge <jimbe@google.com>


### PR DESCRIPTION
Also:
- Improve speed of "print" by seeking instead of reading
- Add error message during extract if tar file is truncated