### PR TITLE
tar: Fix security issue, directory permissions not recreated

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -61,3 +61,4 @@ Authors/contributors include:
 © 2015 Wolfgang Corcoran-Mathe <wcm@sigwinch.xyz>
 © 2016 Mattias Andrée <maandree@kth.se>
 © 2016 Eivind Uggedal <eivind@uggedal.com>
+© 2017 Jim Beveridge <jimbe@google.com>


### PR DESCRIPTION
Directories were being created twice. The first time created
the directory with arbitrary default permissions. The second
time failed (and gave a spurious error) because the directory
already existed due to the first call.

Also:
- Add support for short reads, especially from pipes through ssh.
- Improve read/write performance on systems without read/write caching.
- Improve speed of skipblk() by seeking instead of reading on
  handles that support it.
- Add error message during extract if tar file is truncated.